### PR TITLE
BUGFIX | Correctly qualify translated attributes

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -578,4 +578,19 @@ trait Translatable
 
         return parent::syncOriginal();
     }
+
+    /**
+     * Prefix column names with translation table instead of model table
+     * if the given column is translated.
+     * @param $column
+     * @return string
+     */
+    public function qualifyColumn($column)
+    {
+        if (\in_array($column, $this->translatableAttributes(), true)) {
+            return sprintf('%s.%s', $this->getI18nTable(), $column);
+        }
+        return parent::qualifyColumn($column);
+    }
+
 }

--- a/tests/TestQuery.php
+++ b/tests/TestQuery.php
@@ -97,6 +97,16 @@ class TestQuery extends TestCase
         $this->assertEquals(['de', 'en', 1, 'my title'], $queryOr->getBindings());
     }
 
+    public function testQualifiesTranslatedPropertiesCorrectly()
+    {
+        $this->assertEquals('users_i18n.bio', User::query()->qualifyColumn('bio'));
+    }
+
+    public function testQualifiesUntranslatedPropertiesCorrectly()
+    {
+        $this->assertEquals('users.name', User::query()->qualifyColumn('name'));
+    }
+
     protected function getJoinWithFallbackSql()
     {
         return 'select "posts".*, '.


### PR DESCRIPTION
Before this, a call to `Builder::qualifyColumn` would always prepend the
models table name, even if the attribute was translated.

This fix prefixes the translation table name if the attribute is in that
table.